### PR TITLE
Add Royal Cornwall (REF) to lookup

### DIFF
--- a/data/scheme-lookup.csv
+++ b/data/scheme-lookup.csv
@@ -28,3 +28,4 @@ Imperial College Healthcare NHS Trust,Hammersmith,RYJ
 Nottingham University Hospitals NHS Trust,Nottingham,RX1
 West Suffolk NHS Foundation Trust,West Suffolk,RGR
 Milton Keynes University Hospital NHS Foundation Trust,Milton Keynes,RD8
+Royal Cornwall Hospitals NHS Trust,Royal Cornwall,REF


### PR DESCRIPTION
REF are not in the original NHP list. Will allow #51 to work properly.