### PR TITLE
Add script to generate gynae/paeds/maternity figures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.yml
 
 # Other ignored files/folders
+outputs/
 README_files/
 secret/
 scenarios.R

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,9 @@
+# `dev/`
+
+The scripts in this folder are for developments related to new functionality in the main codebase.
+This is a discrete place for testing approaches, away from the scripts in `R/`.
+
+We should expect content here to be integrated into the main codebase when ready.
+Otherwise, consider moving any scripts here into the [nhp_output_adhocs](https://github.com/the-Strategy-Unit/nhp_output_adhocs) repo, or possibly [nhp_analysis](https://github.com/the-Strategy-Unit/nhp_analysis) if more generic.
+
+By default, any ad hoc work related to outputs (that isn't directly related to producing output reports) should go in the [nhp_output_adhocs](https://github.com/the-Strategy-Unit/nhp_output_adhocs) repo.

--- a/dev/mat-gynae-paeds.R
+++ b/dev/mat-gynae-paeds.R
@@ -475,39 +475,6 @@ plots_icf_mat <- make_icf_charts(maternity = TRUE)
 # beeswarms/S-curves section above
 
 # Function adapted from a Shiny renderText and reactive in nhp_outputs
-generate_ecdf_text <- function(
-  selected_data,
-  selected_measure,
-  selected_site
-) {
-  # Extracted from the aggregated_data() Shiny reactive
-  dat <- selected_data |>
-    mod_model_results_distribution_get_data(
-      selected_measure,
-      selected_site
-    )
-
-  # Calculate y value for principal x value (find nearest % for the principal)
-  p <- dat$principal[[1]]
-  ecdf_fn <- stats::ecdf(dat[["value"]])
-  x_vals <- sort(dat[["value"]])
-  y_vals <- sort(ecdf_fn(dat[["value"]]))
-  principal_diffs <- abs(p - x_vals) # nearest x in ECDF to the principal
-  min_principal_diff_i <- which(principal_diffs == min(principal_diffs))[1]
-  p_pcnt <- y_vals[min_principal_diff_i] |> scales::percent(accuracy = 1)
-
-  list(
-    baseline = dat$baseline[[1]],
-    principal = p,
-    prinicpal_percent = p_pcnt,
-    p10_val = stats::quantile(ecdf_fn, probs = 0.1),
-    p90_val = stats::quantile(ecdf_fn, probs = 0.9)
-  )
-}
-
-generate_ecdf_text(r_primary, "beddays", "REF12")
-
-
 get_ecdf_quantiles_data <- function(data) {
   ecdf_fn <- stats::ecdf(data[["value"]])
 

--- a/dev/mat-gynae-paeds.R
+++ b/dev/mat-gynae-paeds.R
@@ -1,0 +1,202 @@
+# Goal: produce nhp_output_reports charts for:
+#   1. Gynae (treatment specialties 502 and 503)
+#   2. Paeds (ages 0 to 17)
+#   3. Maternity (the POD)
+#
+# See https://github.com/The-Strategy-Unit/nhp_output_reports/issues/54
+#
+# General approach for gynae/paeds: load all functions, then overwrite certain
+# data wrangling functions so that they read datasets needed for gynae/paeds
+# plots/tables. This is controlled by setting a 'results_type' global option()
+# to "gynae" or "paeds".
+
+# Set up ----
+
+# Load all existing functions, overwrite later with bespoke versions
+purrr::walk(list.files("R", ".R$", , TRUE, TRUE), source)
+
+# Read results/sites as per insert_into_template()
+scheme_code <- "XYZ" # replace with scheme of interest
+result_sets <- get_nhp_result_sets()
+run_stages <- list(
+  primary = "final_report_ndg2",
+  secondary = "final_report_ndg3"
+)
+meta <- get_run_metadata(scheme_code, result_sets, run_stages)
+site_codes <- get_sites(scheme_code)
+primary_file <- dplyr::pull(meta$metadata_primary, file)
+secondary_file <- dplyr::pull(meta$metadata_secondary, file)
+r_primary <- get_nhp_results(file = primary_file)
+r_secondary <- get_nhp_results(file = secondary_file)
+
+# Helper functions ----
+
+# Selects a dataset depending on the value of the "results_type" option
+switch_results_data <- function(r) {
+  switch(
+    getOption("results_type", default = NA_character_),
+    "gynae" = r[["results"]][["tretspef"]] |>
+      dplyr::filter(tretspef %in% c("502", "503")),
+    "paeds" = r[["results"]][["age"]] |>
+      dplyr::filter(dplyr::between(age, 0, 17)),
+    r[["results"]][["default"]] # original default behaviour
+  )
+}
+
+# Generate beeswarms and S-curves ----
+
+# Bespoke version of existing function
+get_model_run_distribution <- function(r, pod, measure, site_codes) {
+  filtered_results <- switch_results_data(r) |> # bespoke data switch
+    dplyr::filter(
+      .data$pod %in% .env$pod,
+      .data$measure %in% .env$measure
+    ) |>
+    dplyr::select("sitetret", "baseline", "principal", "model_runs")
+
+  if (nrow(filtered_results) == 0) {
+    return(NULL)
+  }
+
+  filtered_results |>
+    dplyr::mutate(
+      dplyr::across(
+        "model_runs",
+        \(.x) purrr::map(.x, tibble::enframe, name = "model_run")
+      )
+    ) |>
+    tidyr::unnest("model_runs") |>
+    dplyr::inner_join(get_variants(r), by = "model_run") |>
+    trust_site_aggregation(site_codes)
+}
+
+# Convenience function to generate plots and (un)set options
+plot_activity_dist <- function(
+  results = r_primary,
+  sites = site_codes,
+  results_type = NULL
+) {
+  options(results_type = results_type)
+  on.exit(options(results_type = NULL))
+  prepare_all_activity_distribution_plots(results, sites)
+}
+
+# Generate primary-scenario beeswarms (9.1, 9.6, 9.8), S-curves (9.2, 9.7, 9.9)
+plots_activity_distribution <- plot_activity_dist() # overall
+plots_activity_distribution_paeds <- plot_activity_dist(results_type = "paeds")
+plots_activity_distribution_gynae <- plot_activity_dist(results_type = "gynae")
+
+# Generate secondary-scenario beeswarm (9.10) and S-curve (9.11)
+plots_activity_distribution <- plot_activity_dist(results = r_secondary) # overall
+plots_activity_distribution_paeds <- plot_activity_dist(
+  results = r_secondary,
+  results_type = "paeds"
+)
+plots_activity_distribution_gynae <- plot_activity_dist(
+  results = r_secondary,
+  results_type = "gynae"
+)
+
+# Generate summary tables ----
+
+# Bespoke version of existing function
+get_principal_high_level <- function(r, measures, sites) {
+  switch_results_data(r) |> # bespoke data switch
+    dplyr::filter(.data$measure %in% measures) |>
+    dplyr::select("pod", "sitetret", "baseline", "principal") |>
+    dplyr::mutate(dplyr::across(
+      "pod",
+      ~ ifelse(
+        stringr::str_starts(.x, "aae"),
+        "aae",
+        .x
+      )
+    )) |>
+    dplyr::group_by(.data$pod, .data$sitetret) |>
+    dplyr::summarise(dplyr::across(where(is.numeric), sum), .groups = "drop") |>
+    trust_site_aggregation(sites)
+}
+
+# Convenience function to generate plots and (un)set options
+make_summary_table <- function(
+  results = r_primary,
+  sites = site_codes[["ip"]],
+  results_type = NULL
+) {
+  options(results_type = results_type)
+  on.exit(options(results_type = NULL))
+  mod_principal_summary_data(results, sites) |>
+    dplyr::filter(activity_type == "Inpatient") |>
+    mod_principal_summary_table()
+}
+
+# Generate summary table (9.3)
+summary_table <- make_summary_table() # overall
+summary_table_gynae <- make_summary_table(results_type = "gynae")
+summary_table_paeds <- make_summary_table(results_type = "paeds")
+
+# Ganerate LoS tables ----
+
+# Bespoke version of existing function
+mod_principal_summary_los_data <- function(r, sites, measure) {
+  pods <- mod_principal_los_pods()
+
+  has_tretspef_los <- !is.null(r$results[["tretspef+los_group"]])
+  is_gynae <- getOption("results_type", default = "none") == "gynae"
+
+  if (!has_tretspef_los) {
+    if (is_gynae) {
+      stop("Can't produce an output for gynae, tretspef+los_group is missing.")
+    }
+    los_data <- r$results[["los_group"]]
+  }
+
+  if (has_tretspef_los) {
+    los_data <- r$results[["tretspef+los_group"]]
+    if (is_gynae) {
+      los_data <- los_data |> dplyr::filter(tretspef %in% c("502", "503"))
+    }
+    los_data <- los_data |> dplyr::select(-"tretspef")
+  }
+
+  summary_los <- los_data |>
+    dplyr::filter(.data$measure == .env$measure) |>
+    trust_site_aggregation(sites) |>
+    dplyr::inner_join(pods, by = "pod") |>
+    dplyr::mutate(
+      change = .data$principal - .data$baseline,
+      change_pcnt = .data$change / .data$baseline
+    ) |>
+    dplyr::select(
+      "pod_name",
+      "los_group",
+      "baseline",
+      "principal",
+      "change",
+      "change_pcnt"
+    ) |>
+    dplyr::arrange("pod_name", "los_group")
+
+  summary_los[order(summary_los$pod_name, summary_los$los_group), ]
+}
+
+# Convenience function to generate plots and (un)set options
+make_summary_los_table <- function(
+  results = r_primary,
+  sites = site_codes[["ip"]],
+  results_type = NULL
+) {
+  options(results_type = results_type)
+  on.exit(options(results_type = NULL))
+  mod_principal_summary_los_data(results, sites, "beddays") |>
+    dplyr::mutate(
+      pod_name = stringr::str_replace(pod_name, "Admission", "Bed Days")
+    ) |>
+    dplyr::arrange(pod_name, los_group) |>
+    mod_principal_summary_los_table() |>
+    gt::tab_options(table.align = "left")
+}
+
+# Generate LoS table (9.5)
+make_summary_los_table() # overall
+make_summary_los_table(results_type = "gynae")

--- a/dev/mat-gynae-paeds.R
+++ b/dev/mat-gynae-paeds.R
@@ -37,9 +37,12 @@ switch_results_data <- function(results) {
   switch(
     getOption("results_type", default = NA_character_),
     "gynae" = results[["results"]][["tretspef"]] |>
-      dplyr::filter(tretspef %in% c("502", "503")),
+      dplyr::filter(
+        tretspef %in% c("502", "503"), # gynae-specific treatment specialties
+        !purrr::map_lgl(model_runs, is.null) # listcol must contain runs
+      ),
     "paeds" = results[["results"]][["age"]] |>
-      dplyr::filter(dplyr::between(age, 0, 17)),
+      dplyr::filter(dplyr::between(age, 0, 17)), # inclusive of 0 and 17
     results[["results"]][["default"]] # otherwise original default behaviour
   )
 }

--- a/dev/mat-gynae-paeds.R
+++ b/dev/mat-gynae-paeds.R
@@ -337,7 +337,7 @@ summary_los_table <- make_summary_los_table() # overall
 summary_los_table_gynae <- make_summary_los_table(results_type = "gynae")
 summary_los_table_mat <- make_summary_los_table(maternity = TRUE)
 
-# Generate individual change-factor charts ----
+# Generate waterfall ----
 
 # Bespoke version of existing function
 prepare_all_principal_change_factors <- function(
@@ -402,6 +402,36 @@ prepare_all_principal_change_factors <- function(
 
   principal_change_data
 }
+
+# Convenience function to generate plots and (un)set options
+plot_waterfall <- function(
+  results = r_primary,
+  sites = site_codes,
+  maternity = NULL # set maternity option
+) {
+  options(maternity = maternity)
+  on.exit(options(maternity = NULL))
+
+  cat(
+    "* maternity option:",
+    getOption("maternity", default = "none"),
+    "\n"
+  )
+
+  prepare_all_principal_change_factors(results, site_codes) |>
+    _$ip |> # only need inpatients
+    mod_principal_change_factor_effects_summarised("beddays", TRUE) |>
+    mod_principal_change_factor_effects_cf_plot()
+}
+
+# Generate waterfall chart (9.4)
+waterfall <- plot_waterfall() # overall
+waterfall_mat <- plot_waterfall(maternity = TRUE)
+
+# Generate individual change-factor charts ----
+
+# Bespoke version of existing function: use the same bespoke version of the
+# prepare_all_principal_change_factors() used in the waterfall generation above.
 
 # Convenience function to generate plots and (un)set options
 make_icf_charts <- function(

--- a/dev/mat-gynae-paeds.R
+++ b/dev/mat-gynae-paeds.R
@@ -532,19 +532,20 @@ get_ecdf_quantiles <- function(data, site_codes, activity_type, pods, measure) {
   )
 }
 
-
 atmpo <- read_atmpo()
 at <- "inpatients"
 m <- "beddays"
-atmpo_ip <- atmpo |>
+pods <- atmpo |>
   dplyr::filter(
+    # could also filter for pod == ip_maternity_admission only
     activity_type == at,
-    measure = m
-  )
+    measure == m
+  ) |>
+  dplyr::pull(pod)
 
-get_ecdf_quantiles(r_primary, site_codes, "ip", pods, "beddays")
+get_ecdf_quantiles(r_primary, site_codes, at, pods, m)
 options(results_type = "gynae")
-get_ecdf_quantiles(r_primary, site_codes, "ip", pods, "beddays")
+get_ecdf_quantiles(r_primary, site_codes, at, pods, m)
 options(results_type = "paeds")
-get_ecdf_quantiles(r_primary, site_codes, "ip", pods, "beddays")
+get_ecdf_quantiles(r_primary, site_codes, at, pods, m)
 options(results_type = NULL)

--- a/renv.lock
+++ b/renv.lock
@@ -1217,7 +1217,7 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "4.0.0",
+      "Version": "4.0.1",
       "Source": "Repository",
       "Title": "Create Elegant Data Visualisations Using the Grammar of Graphics",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\", comment = c(ORCID = \"0000-0003-4757-117X\")), person(\"Winston\", \"Chang\", role = \"aut\", comment = c(ORCID = \"0000-0002-1576-2126\")), person(\"Lionel\", \"Henry\", role = \"aut\"), person(\"Thomas Lin\", \"Pedersen\", , \"thomas.pedersen@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-5147-4711\")), person(\"Kohske\", \"Takahashi\", role = \"aut\"), person(\"Claus\", \"Wilke\", role = \"aut\", comment = c(ORCID = \"0000-0002-7470-9261\")), person(\"Kara\", \"Woo\", role = \"aut\", comment = c(ORCID = \"0000-0002-5125-4188\")), person(\"Hiroaki\", \"Yutani\", role = \"aut\", comment = c(ORCID = \"0000-0002-3385-7233\")), person(\"Dewey\", \"Dunnington\", role = \"aut\", comment = c(ORCID = \"0000-0002-9415-4582\")), person(\"Teun\", \"van den Brand\", role = \"aut\", comment = c(ORCID = \"0000-0002-9335-7468\")), person(\"Posit, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
@@ -1249,6 +1249,7 @@
         "ggplot2movies",
         "hexbin",
         "Hmisc",
+        "hms",
         "knitr",
         "mapproj",
         "maps",
@@ -1259,9 +1260,9 @@
         "nlme",
         "profvis",
         "quantreg",
+        "quarto",
         "ragg (>= 1.2.6)",
         "RColorBrewer",
-        "rmarkdown",
         "roxygen2",
         "rpart",
         "sf (>= 0.7-3)",
@@ -1274,13 +1275,13 @@
       "Enhances": [
         "sp"
       ],
-      "VignetteBuilder": "knitr",
+      "VignetteBuilder": "quarto",
       "Config/Needs/website": "ggtext, tidyr, forcats, tidyverse/tidytemplate",
       "Config/testthat/edition": "3",
       "Config/usethis/last-upkeep": "2025-04-23",
       "Encoding": "UTF-8",
       "LazyData": "true",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "Collate": "'ggproto.R' 'ggplot-global.R' 'aaa-.R' 'aes-colour-fill-alpha.R' 'aes-evaluation.R' 'aes-group-order.R' 'aes-linetype-size-shape.R' 'aes-position.R' 'all-classes.R' 'compat-plyr.R' 'utilities.R' 'aes.R' 'annotation-borders.R' 'utilities-checks.R' 'legend-draw.R' 'geom-.R' 'annotation-custom.R' 'annotation-logticks.R' 'scale-type.R' 'layer.R' 'make-constructor.R' 'geom-polygon.R' 'geom-map.R' 'annotation-map.R' 'geom-raster.R' 'annotation-raster.R' 'annotation.R' 'autolayer.R' 'autoplot.R' 'axis-secondary.R' 'backports.R' 'bench.R' 'bin.R' 'coord-.R' 'coord-cartesian-.R' 'coord-fixed.R' 'coord-flip.R' 'coord-map.R' 'coord-munch.R' 'coord-polar.R' 'coord-quickmap.R' 'coord-radial.R' 'coord-sf.R' 'coord-transform.R' 'data.R' 'docs_layer.R' 'facet-.R' 'facet-grid-.R' 'facet-null.R' 'facet-wrap.R' 'fortify-map.R' 'fortify-models.R' 'fortify-spatial.R' 'fortify.R' 'stat-.R' 'geom-abline.R' 'geom-rect.R' 'geom-bar.R' 'geom-tile.R' 'geom-bin2d.R' 'geom-blank.R' 'geom-boxplot.R' 'geom-col.R' 'geom-path.R' 'geom-contour.R' 'geom-point.R' 'geom-count.R' 'geom-crossbar.R' 'geom-segment.R' 'geom-curve.R' 'geom-defaults.R' 'geom-ribbon.R' 'geom-density.R' 'geom-density2d.R' 'geom-dotplot.R' 'geom-errorbar.R' 'geom-freqpoly.R' 'geom-function.R' 'geom-hex.R' 'geom-histogram.R' 'geom-hline.R' 'geom-jitter.R' 'geom-label.R' 'geom-linerange.R' 'geom-pointrange.R' 'geom-quantile.R' 'geom-rug.R' 'geom-sf.R' 'geom-smooth.R' 'geom-spoke.R' 'geom-text.R' 'geom-violin.R' 'geom-vline.R' 'ggplot2-package.R' 'grob-absolute.R' 'grob-dotstack.R' 'grob-null.R' 'grouping.R' 'properties.R' 'margins.R' 'theme-elements.R' 'guide-.R' 'guide-axis.R' 'guide-axis-logticks.R' 'guide-axis-stack.R' 'guide-axis-theta.R' 'guide-legend.R' 'guide-bins.R' 'guide-colorbar.R' 'guide-colorsteps.R' 'guide-custom.R' 'guide-none.R' 'guide-old.R' 'guides-.R' 'guides-grid.R' 'hexbin.R' 'import-standalone-obj-type.R' 'import-standalone-types-check.R' 'labeller.R' 'labels.R' 'layer-sf.R' 'layout.R' 'limits.R' 'performance.R' 'plot-build.R' 'plot-construction.R' 'plot-last.R' 'plot.R' 'position-.R' 'position-collide.R' 'position-dodge.R' 'position-dodge2.R' 'position-identity.R' 'position-jitter.R' 'position-jitterdodge.R' 'position-nudge.R' 'position-stack.R' 'quick-plot.R' 'reshape-add-margins.R' 'save.R' 'scale-.R' 'scale-alpha.R' 'scale-binned.R' 'scale-brewer.R' 'scale-colour.R' 'scale-continuous.R' 'scale-date.R' 'scale-discrete-.R' 'scale-expansion.R' 'scale-gradient.R' 'scale-grey.R' 'scale-hue.R' 'scale-identity.R' 'scale-linetype.R' 'scale-linewidth.R' 'scale-manual.R' 'scale-shape.R' 'scale-size.R' 'scale-steps.R' 'scale-view.R' 'scale-viridis.R' 'scales-.R' 'stat-align.R' 'stat-bin.R' 'stat-summary-2d.R' 'stat-bin2d.R' 'stat-bindot.R' 'stat-binhex.R' 'stat-boxplot.R' 'stat-connect.R' 'stat-contour.R' 'stat-count.R' 'stat-density-2d.R' 'stat-density.R' 'stat-ecdf.R' 'stat-ellipse.R' 'stat-function.R' 'stat-identity.R' 'stat-manual.R' 'stat-qq-line.R' 'stat-qq.R' 'stat-quantilemethods.R' 'stat-sf-coordinates.R' 'stat-sf.R' 'stat-smooth-methods.R' 'stat-smooth.R' 'stat-sum.R' 'stat-summary-bin.R' 'stat-summary-hex.R' 'stat-summary.R' 'stat-unique.R' 'stat-ydensity.R' 'summarise-plot.R' 'summary.R' 'theme.R' 'theme-defaults.R' 'theme-current.R' 'theme-sub.R' 'utilities-break.R' 'utilities-grid.R' 'utilities-help.R' 'utilities-patterns.R' 'utilities-resolution.R' 'utilities-tidy-eval.R' 'zxx.R' 'zzz.R'",
       "NeedsCompilation": "no",
       "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>), Lionel Henry [aut], Thomas Lin Pedersen [aut, cre] (ORCID: <https://orcid.org/0000-0002-5147-4711>), Kohske Takahashi [aut], Claus Wilke [aut] (ORCID: <https://orcid.org/0000-0002-7470-9261>), Kara Woo [aut] (ORCID: <https://orcid.org/0000-0002-5125-4188>), Hiroaki Yutani [aut] (ORCID: <https://orcid.org/0000-0002-3385-7233>), Dewey Dunnington [aut] (ORCID: <https://orcid.org/0000-0002-9415-4582>), Teun van den Brand [aut] (ORCID: <https://orcid.org/0000-0002-9335-7468>), Posit, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
@@ -2234,7 +2235,7 @@
     },
     "officer": {
       "Package": "officer",
-      "Version": "0.7.0",
+      "Version": "0.7.1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Manipulation of Microsoft Word and PowerPoint Documents",
@@ -2245,12 +2246,14 @@
       "BugReports": "https://github.com/davidgohel/officer/issues",
       "Imports": [
         "cli",
+        "dplyr",
         "graphics",
         "grDevices",
         "openssl",
         "R6",
         "ragg",
         "stats",
+        "tidyr",
         "utils",
         "uuid",
         "xml2 (>= 1.1.0)",
@@ -2269,8 +2272,8 @@
         "withr"
       ],
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
-      "Collate": "'core_properties.R' 'custom_properties.R' 'defunct.R' 'dev-utils.R' 'docx_add.R' 'docx_comments.R' 'docx_cursor.R' 'docx_part.R' 'docx_replace.R' 'docx_section.R' 'docx_settings.R' 'empty_content.R' 'formatting_properties.R' 'fortify_docx.R' 'fortify_pptx.R' 'knitr_utils.R' 'officer.R' 'ooxml.R' 'ooxml_block_objects.R' 'ooxml_run_objects.R' 'openxml_content_type.R' 'openxml_document.R' 'pack_folder.R' 'ph_location.R' 'post-proc.R' 'ppt_class_dir_collection.R' 'ppt_classes.R' 'ppt_notes.R' 'ppt_ph_dedupe_layout.R' 'ppt_ph_manipulate.R' 'ppt_ph_rename_layout.R' 'ppt_ph_with_methods.R' 'pptx_informations.R' 'pptx_layout_helper.R' 'pptx_matrix.R' 'utils.R' 'pptx_slide_manip.R' 'read_docx.R' 'read_docx_styles.R' 'read_pptx.R' 'read_xlsx.R' 'relationship.R' 'rtf.R' 'shape_properties.R' 'shorcuts.R' 'docx_append_context.R' 'utils-xml.R' 'deprecated.R' 'zzz.R'",
+      "RoxygenNote": "7.3.3",
+      "Collate": "'core_properties.R' 'custom_properties.R' 'defunct.R' 'dev-utils.R' 'docx_add.R' 'docx_comments.R' 'docx_cursor.R' 'docx_part.R' 'docx_replace.R' 'docx_section.R' 'docx_settings.R' 'docx_styles.R' 'docx_utils_funs.R' 'empty_content.R' 'formatting_properties.R' 'fortify_docx.R' 'fortify_pptx.R' 'knitr_utils.R' 'officer.R' 'ooxml.R' 'ooxml_block_objects.R' 'ooxml_run_objects.R' 'openxml_content_type.R' 'openxml_document.R' 'pack_folder.R' 'ph_location.R' 'post-proc.R' 'ppt_class_dir_collection.R' 'ppt_classes.R' 'ppt_notes.R' 'ppt_ph_dedupe_layout.R' 'ppt_ph_manipulate.R' 'ppt_ph_rename_layout.R' 'ppt_ph_with_methods.R' 'pptx_informations.R' 'pptx_layout_helper.R' 'pptx_matrix.R' 'utils.R' 'pptx_slide_manip.R' 'read_docx.R' 'docx_write.R' 'read_docx_styles.R' 'read_pptx.R' 'read_xlsx.R' 'relationship.R' 'rtf.R' 'shape_properties.R' 'shorcuts.R' 'docx_append_context.R' 'utils-xml.R' 'deprecated.R' 'zzz.R'",
       "NeedsCompilation": "no",
       "Author": "David Gohel [aut, cre], Stefan Moog [aut], Mark Heckmann [aut] (ORCID: <https://orcid.org/0000-0002-0736-7417>), ArData [cph], Frank Hangler [ctb] (function body_replace_all_text), Liz Sander [ctb] (several documentation fixes), Anton Victorson [ctb] (fixes xml structures), Jon Calder [ctb] (update vignettes), John Harrold [ctb] (function annotate_base), John Muschelli [ctb] (google doc compatibility), Bill Denney [ctb] (ORCID: <https://orcid.org/0000-0002-5759-428X>, function as.matrix.rpptx), Nikolai Beck [ctb] (set speaker notes for .pptx documents), Greg Leleu [ctb] (fields functionality in ppt), Majid Eismann [ctb], Hongyuan Jia [ctb] (ORCID: <https://orcid.org/0000-0002-0075-8183>), Michael Stackhouse [ctb]",
       "Maintainer": "David Gohel <david.gohel@ardata.fr>",
@@ -2512,7 +2515,7 @@
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "1.1.0",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Title": "Functional Programming Tools",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0003-4757-117X\")), person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = \"aut\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"https://ror.org/03wc8by49\")) )",
@@ -2531,13 +2534,13 @@
         "vctrs (>= 0.6.3)"
       ],
       "Suggests": [
-        "carrier (>= 0.2.0)",
+        "carrier (>= 0.3.0)",
         "covr",
         "dplyr (>= 0.7.8)",
         "httr",
         "knitr",
         "lubridate",
-        "mirai (>= 2.4.0)",
+        "mirai (>= 2.5.1)",
         "rmarkdown",
         "testthat (>= 3.0.0)",
         "tibble",
@@ -2553,7 +2556,7 @@
       "Config/testthat/edition": "3",
       "Config/testthat/parallel": "TRUE",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
       "Author": "Hadley Wickham [aut, cre] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Lionel Henry [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Maintainer": "Hadley Wickham <hadley@posit.co>",
@@ -2561,11 +2564,11 @@
     },
     "ragg": {
       "Package": "ragg",
-      "Version": "1.4.0",
+      "Version": "1.5.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Graphic Devices Based on AGG",
-      "Authors@R": "c( person(\"Thomas Lin\", \"Pedersen\", , \"thomas.pedersen@posit.co\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0002-5147-4711\")), person(\"Maxim\", \"Shemanarev\", role = c(\"aut\", \"cph\"), comment = \"Author of AGG\"), person(\"Tony\", \"Juricic\", , \"tonygeek@yahoo.com\", role = c(\"ctb\", \"cph\"), comment = \"Contributor to AGG\"), person(\"Milan\", \"Marusinec\", , \"milan@marusinec.sk\", role = c(\"ctb\", \"cph\"), comment = \"Contributor to AGG\"), person(\"Spencer\", \"Garrett\", role = \"ctb\", comment = \"Contributor to AGG\"), person(\"Posit, PBC\", role = c(\"cph\", \"fnd\")) )",
+      "Authors@R": "c( person(\"Thomas Lin\", \"Pedersen\", , \"thomas.pedersen@posit.co\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0002-5147-4711\")), person(\"Maxim\", \"Shemanarev\", role = c(\"aut\", \"cph\"), comment = \"Author of AGG\"), person(\"Tony\", \"Juricic\", , \"tonygeek@yahoo.com\", role = c(\"ctb\", \"cph\"), comment = \"Contributor to AGG\"), person(\"Milan\", \"Marusinec\", , \"milan@marusinec.sk\", role = c(\"ctb\", \"cph\"), comment = \"Contributor to AGG\"), person(\"Spencer\", \"Garrett\", role = \"ctb\", comment = \"Contributor to AGG\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
       "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
       "Description": "Anti-Grain Geometry (AGG) is a high-quality and high-performance 2D drawing library. The 'ragg' package provides a set of graphic devices based on AGG to use as alternative to the raster devices provided through the 'grDevices' package.",
       "License": "MIT + file LICENSE",
@@ -2585,14 +2588,15 @@
         "systemfonts",
         "textshaping"
       ],
+      "Config/build/compilation-database": "true",
       "Config/Needs/website": "ggplot2, devoid, magick, bench, tidyr, ggridges, hexbin, sessioninfo, pkgdown, tidyverse/tidytemplate",
+      "Config/testthat/edition": "3",
+      "Config/usethis/last-upkeep": "2025-04-25",
       "Encoding": "UTF-8",
       "RoxygenNote": "7.3.2",
-      "SystemRequirements": "freetype2, libpng, libtiff, libjpeg",
-      "Config/testthat/edition": "3",
-      "Config/build/compilation-database": "true",
+      "SystemRequirements": "freetype2, libpng, libtiff, libjpeg, libwebp, libwebpmux",
       "NeedsCompilation": "yes",
-      "Author": "Thomas Lin Pedersen [cre, aut] (<https://orcid.org/0000-0002-5147-4711>), Maxim Shemanarev [aut, cph] (Author of AGG), Tony Juricic [ctb, cph] (Contributor to AGG), Milan Marusinec [ctb, cph] (Contributor to AGG), Spencer Garrett [ctb] (Contributor to AGG), Posit, PBC [cph, fnd]",
+      "Author": "Thomas Lin Pedersen [cre, aut] (ORCID: <https://orcid.org/0000-0002-5147-4711>), Maxim Shemanarev [aut, cph] (Author of AGG), Tony Juricic [ctb, cph] (Contributor to AGG), Milan Marusinec [ctb, cph] (Contributor to AGG), Spencer Garrett [ctb] (Contributor to AGG), Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
       "Repository": "CRAN"
     },
     "rappdirs": {
@@ -2702,7 +2706,7 @@
     },
     "readr": {
       "Package": "readr",
-      "Version": "2.1.5",
+      "Version": "2.1.6",
       "Source": "Repository",
       "Title": "Read Rectangular Text Data",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\"), person(\"Jim\", \"Hester\", role = \"aut\"), person(\"Romain\", \"Francois\", role = \"ctb\"), person(\"Jennifer\", \"Bryan\", , \"jenny@posit.co\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-6983-2759\")), person(\"Shelby\", \"Bearrows\", role = \"ctb\"), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")), person(\"https://github.com/mandreyel/\", role = \"cph\", comment = \"mio library\"), person(\"Jukka\", \"Jylänki\", role = c(\"ctb\", \"cph\"), comment = \"grisu3 implementation\"), person(\"Mikkel\", \"Jørgensen\", role = c(\"ctb\", \"cph\"), comment = \"grisu3 implementation\") )",
@@ -2750,9 +2754,9 @@
       "Config/testthat/parallel": "false",
       "Encoding": "UTF-8",
       "Language": "en-US",
-      "RoxygenNote": "7.2.3",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "yes",
-      "Author": "Hadley Wickham [aut], Jim Hester [aut], Romain Francois [ctb], Jennifer Bryan [aut, cre] (<https://orcid.org/0000-0002-6983-2759>), Shelby Bearrows [ctb], Posit Software, PBC [cph, fnd], https://github.com/mandreyel/ [cph] (mio library), Jukka Jylänki [ctb, cph] (grisu3 implementation), Mikkel Jørgensen [ctb, cph] (grisu3 implementation)",
+      "Author": "Hadley Wickham [aut], Jim Hester [aut], Romain Francois [ctb], Jennifer Bryan [aut, cre] (ORCID: <https://orcid.org/0000-0002-6983-2759>), Shelby Bearrows [ctb], Posit Software, PBC [cph, fnd], https://github.com/mandreyel/ [cph] (mio library), Jukka Jylänki [ctb, cph] (grisu3 implementation), Mikkel Jørgensen [ctb, cph] (grisu3 implementation)",
       "Maintainer": "Jennifer Bryan <jenny@posit.co>",
       "Repository": "CRAN"
     },
@@ -3156,7 +3160,7 @@
     },
     "stringr": {
       "Package": "stringr",
-      "Version": "1.5.2",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Title": "Simple, Consistent Wrappers for Common String Operations",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\", \"cph\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
@@ -3165,7 +3169,7 @@
       "URL": "https://stringr.tidyverse.org, https://github.com/tidyverse/stringr",
       "BugReports": "https://github.com/tidyverse/stringr/issues",
       "Depends": [
-        "R (>= 3.6)"
+        "R (>= 4.1.0)"
       ],
       "Imports": [
         "cli",
@@ -3189,10 +3193,11 @@
       ],
       "VignetteBuilder": "knitr",
       "Config/Needs/website": "tidyverse/tidytemplate",
+      "Config/potools/style": "explicit",
       "Config/testthat/edition": "3",
       "Encoding": "UTF-8",
       "LazyData": "true",
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "NeedsCompilation": "no",
       "Author": "Hadley Wickham [aut, cre, cph], Posit Software, PBC [cph, fnd]",
       "Maintainer": "Hadley Wickham <hadley@posit.co>",
@@ -3224,7 +3229,7 @@
     },
     "systemfonts": {
       "Package": "systemfonts",
-      "Version": "1.2.3",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "System Native Font Finding",
@@ -3247,9 +3252,12 @@
       "Suggests": [
         "covr",
         "farver",
+        "ggplot2",
         "graphics",
         "knitr",
+        "ragg",
         "rmarkdown",
+        "svglite",
         "testthat (>= 2.1.0)"
       ],
       "LinkingTo": [
@@ -3269,11 +3277,11 @@
     },
     "textshaping": {
       "Package": "textshaping",
-      "Version": "1.0.1",
+      "Version": "1.0.4",
       "Source": "Repository",
       "Title": "Bindings to the 'HarfBuzz' and 'Fribidi' Libraries for Text Shaping",
       "Authors@R": "c( person(\"Thomas Lin\", \"Pedersen\", , \"thomas.pedersen@posit.co\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0002-5147-4711\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"), comment = c(ROR = \"03wc8by49\")) )",
-      "Description": "Provides access to the text shaping functionality in the 'HarfBuzz' library and the bidirectional algorithm in the 'Fribidi' library.  'textshaping' is a low-level utility package mainly for graphic devices that expands upon the font tool-set provided by the 'systemfonts' package.",
+      "Description": "Provides access to the text shaping functionality in the 'HarfBuzz' library and the bidirectional algorithm in the 'Fribidi' library. 'textshaping' is a low-level utility package mainly for graphic devices that expands upon the font tool-set provided by the 'systemfonts' package.",
       "License": "MIT + file LICENSE",
       "URL": "https://github.com/r-lib/textshaping",
       "BugReports": "https://github.com/r-lib/textshaping/issues",
@@ -3284,7 +3292,7 @@
         "lifecycle",
         "stats",
         "stringi",
-        "systemfonts (>= 1.1.0)",
+        "systemfonts (>= 1.3.0)",
         "utils"
       ],
       "Suggests": [
@@ -3935,21 +3943,22 @@
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.3.10",
+      "Version": "2.3.11",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Methods to Convert R Data to YAML and Back",
-      "Date": "2024-07-22",
+      "Date": "2025-11-06",
       "Suggests": [
         "RUnit"
       ],
-      "Author": "Shawn P Garbett [aut], Jeremy Stephens [aut, cre], Kirill Simonov [aut], Yihui Xie [ctb], Zhuoer Dong [ctb], Hadley Wickham [ctb], Jeffrey Horner [ctb], reikoch [ctb], Will Beasley [ctb], Brendan O'Connor [ctb], Gregory R. Warnes [ctb], Michael Quinn [ctb], Zhian N. Kamvar [ctb], Charlie Gao [ctb]",
+      "Authors@R": "c( person(\"Shawn\",    \"Garbett\",  role = c(\"cre\",\"ctb\"), email   = \"shawn.garbett@vumc.org\", comment = c(ORCID=\"0000-0003-4079-5621\") ), person(\"Jeremy\",  \"Stephens\", role = c(\"aut\", \"ctb\")), person(\"Kirill\",  \"Simonov\",  role = \"aut\"), person(\"Yihui\",   \"Xie\",      role = \"ctb\", comment = c(ORCID=\"0000-0003-0645-5666\")), person(\"Zhuoer\",  \"Dong\",     role = \"ctb\"), person(\"Hadley\",  \"Wickham\",  role = \"ctb\", comment = c(ORCID=\"0000-0003-4757-117X\")), person(\"Jeffrey\", \"Horner\",   role = \"ctb\"), person(\"reikoch\",             role = \"ctb\"), person(\"Will\",    \"Beasley\",  role = \"ctb\", comment = c(ORCID=\"0000-0002-5613-5006\")), person(\"Brendan\", \"O'Connor\", role = \"ctb\"), person(\"Michael\", \"Quinn\",    role = \"ctb\"), person(\"Charlie\", \"Gao\",      role = \"ctb\"), person(c(\"Gregory\", \"R.\"), \"Warnes\", role = \"ctb\"), person(c(\"Zhian\", \"N.\"),   \"Kamvar\", role = \"ctb\") )",
       "Maintainer": "Shawn Garbett <shawn.garbett@vumc.org>",
       "License": "BSD_3_clause + file LICENSE",
       "Description": "Implements the 'libyaml' 'YAML' 1.1 parser and emitter (<https://pyyaml.org/wiki/LibYAML>) for R.",
       "URL": "https://github.com/vubiostat/r-yaml/",
       "BugReports": "https://github.com/vubiostat/r-yaml/issues",
       "NeedsCompilation": "yes",
+      "Author": "Shawn Garbett [cre, ctb] (ORCID: <https://orcid.org/0000-0003-4079-5621>), Jeremy Stephens [aut, ctb], Kirill Simonov [aut], Yihui Xie [ctb] (ORCID: <https://orcid.org/0000-0003-0645-5666>), Zhuoer Dong [ctb], Hadley Wickham [ctb] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Jeffrey Horner [ctb], reikoch [ctb], Will Beasley [ctb] (ORCID: <https://orcid.org/0000-0002-5613-5006>), Brendan O'Connor [ctb], Michael Quinn [ctb], Charlie Gao [ctb], Gregory R. Warnes [ctb], Zhian N. Kamvar [ctb]",
       "Repository": "CRAN"
     },
     "zeallot": {


### PR DESCRIPTION
Close #54.

* Added a script with augmented functions to generate plots/tables for gynae/paeds/maternity, based on the use of `options()`.
* Added script to `dev/` folder to indicate that this is in development and not part of the main codebase at this time.
* Did a new snapshot of {renv} (do `renv::restore()` before running this script)

> [!IMPORTANT]
>  The script works by loading all the functions in `R/` first, and then selectively overwriting some of those functions with bespoke versions. This means the code should be run linearly, in the order it appears in the script, so that the correct functions are overwritten. This is a bit brittle, but it'll have to do for now.
>
> The bespoke functions will automatically select an appropriate dataset/filter for gynae, paeds or maternity based on the user setting some global options in the form `options(results_type = "gynae")`, `options(results_type = "paeds")` or `options(maternity = TRUE)` (note that `options(results_type = NULL)` and `options(maternity = NULL)` will 'reset' these options).
> 
> I've added convenience functions to the script that set the options, print the options back to the user for confirmation and then reset the options when the function has finished running.

