### PR TITLE
Fix to add missing line of code as the else condition was failing

### DIFF
--- a/R/get_soc_obc.R
+++ b/R/get_soc_obc.R
@@ -47,6 +47,7 @@ if (soc_base_yr == 2019) {
   soc <- soc |>
     dplyr::left_join(get_covid_soc_cagr(r_final_report_ndg2, site_codes))
 } else {
+  soc <- soc |>
   dplyr::mutate(cagr = (principal / baseline) ^ (1/fc_period_soc) - 1,
                 cagr = dplyr::na_if(cagr, Inf))
 }


### PR DESCRIPTION
This original code was tested under the condition of year = 2019 but there was in fact a missing line of code should the year <> 2019 and this fixes that circumstance.